### PR TITLE
Webpack2 SyntaxError Fix

### DIFF
--- a/foundation/webpack/webpack.base.js
+++ b/foundation/webpack/webpack.base.js
@@ -56,7 +56,7 @@ module.exports = (options) => ({
     // drop any unreachable code.
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV) || JSON.stringify('DEVELOPMENT'),
-      'process.env.GRAPHQL_ENDPOINT': process.env.URL,
+      'process.env.GRAPHQL_ENDPOINT': JSON.stringify(process.env.URL),
     }),
   ]),
 


### PR DESCRIPTION
## Description
`webpack.DefinePlugin` likes it when you stringify environment variables and get's angry when you don't. The fix for #71 and #79 was to stringify `process.env.GRAPHQL_ENDPOINT`.