### PR TITLE
fix graphiql bug

### DIFF
--- a/app-backend/handler.js
+++ b/app-backend/handler.js
@@ -23,5 +23,5 @@ exports.graphqlHandler = function graphqlHandler(event, context, callback) {
   return handler(event, context, callbackFilter);
 };
 
-//for local endpointURL is /graphql and for prod it is /stackname/graphql
+//for local endpointURL is /graphql and for prod it is /stage/graphql
 exports.graphiqlHandler = server.graphiqlLambda({ endpointURL: process.env.GRAPHQL_ENDPOINT ? process.env.GRAPHQL_ENDPOINT :'/production/graphql' });

--- a/app-backend/handler.js
+++ b/app-backend/handler.js
@@ -23,4 +23,5 @@ exports.graphqlHandler = function graphqlHandler(event, context, callback) {
   return handler(event, context, callbackFilter);
 };
 
-exports.graphiqlHandler = server.graphiqlLambda({ endpointURL: '/production/graphql' });
+//for local endpointURL is /graphql and for prod it is /stackname/graphql
+exports.graphiqlHandler = server.graphiqlLambda({ endpointURL: process.env.GRAPHQL_ENDPOINT ? process.env.GRAPHQL_ENDPOINT :'/production/graphql' });

--- a/app-backend/handler.js
+++ b/app-backend/handler.js
@@ -23,5 +23,5 @@ exports.graphqlHandler = function graphqlHandler(event, context, callback) {
   return handler(event, context, callbackFilter);
 };
 
-//for local endpointURL is /graphql and for prod it is /stage/graphql
-exports.graphiqlHandler = server.graphiqlLambda({ endpointURL: process.env.GRAPHQL_ENDPOINT ? process.env.GRAPHQL_ENDPOINT :'/production/graphql' });
+// for local endpointURL is /graphql and for prod it is /stage/graphql
+exports.graphiqlHandler = server.graphiqlLambda({ endpointURL: process.env.GRAPHQL_ENDPOINT ? process.env.GRAPHQL_ENDPOINT : '/production/graphql' });

--- a/app-backend/package.json
+++ b/app-backend/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start-client-local": "cd ../app-client/ && npm start",
-    "start-server-lambda:offline": "serverless offline start",
+    "start-server-lambda:offline": "env-cmd ../config/security.env.local serverless offline start",
     "deploy-server-lambda-prod": "serverless --stage=production deploy",
     "lint": "eslint . --cache"
   },

--- a/config/security.env.local
+++ b/config/security.env.local
@@ -1,2 +1,2 @@
-SERVER_URL=/graphql
+GRAPHQL_ENDPOINT=/graphql
 CLIENT_URL=http://localhost:3000


### PR DESCRIPTION
@nikgraf 

endpointURL in handler js is different for offline mode and production mode.

offline mode: /graphql
production mode: /stage/graphql (/production/graphql) 

Right now if we run serverless offline, graphiql doesn't work because there is no stack on local. 
This PR fixes the bug. this problem should be fixed once we finalized configurations in front-end and backend-app code in both serverless offline and production mode.

*I have done functional testing on both offline and production*